### PR TITLE
engines: add rocm_xio ioengine scaffolding

### DIFF
--- a/HOWTO.rst
+++ b/HOWTO.rst
@@ -2345,6 +2345,12 @@ I/O engine
 			:option:`iomem` must not be `cudamalloc`. This ioengine defines
 			engine specific options.
 
+		**rocm_xio**
+			I/O engine supporting synchronous NVMe I/O submission through the
+			ROCm XIO (rocm-xio) userspace stack. This engine is intended for
+			AMD GPU-initiated NVMe paths where queue setup and command
+			submission are driven by rocm-xio.
+
 		**dfs**
 			I/O engine supporting asynchronous read and write operations to the
 			DAOS File System (DFS) via libdfs.
@@ -3233,6 +3239,50 @@ with the caveat that when used on the command line, they must come after the
 		to transfer data between RAM and the GPUs. Data is copied from
 		GPU to RAM before a write and copied from RAM to GPU after a
 		read. :option:`verify` does not affect use of cudaMemcpy.
+
+.. option:: rocm_xio_controller=str : [rocm_xio]
+
+	Path to the NVMe controller node used by rocm-xio, for example
+	:file:`/dev/nvme0`.
+
+.. option:: rocm_xio_gpu_id=int : [rocm_xio]
+
+	HIP GPU device id used for rocm-xio execution. Default is -1, which
+	keeps the current HIP device.
+
+.. option:: rocm_xio_queue_id=int : [rocm_xio]
+
+	NVMe queue id for rocm-xio queue creation. Default is 0, which enables
+	rocm-xio automatic queue id selection.
+
+.. option:: rocm_xio_queue_length=int : [rocm_xio]
+
+	Queue depth (entries) used for the rocm-xio NVMe SQ/CQ pair.
+
+.. option:: rocm_xio_nsid=int : [rocm_xio]
+
+	NVMe namespace id used for I/O commands. Default is 1.
+
+.. option:: rocm_xio_lfsr_seed=int : [rocm_xio]
+
+	LFSR seed passed into rocm-xio data pattern generation.
+
+.. option:: rocm_xio_batch_size=int : [rocm_xio]
+
+	SQEs grouped per doorbell ring in rocm-xio. Default is 1.
+
+.. option:: rocm_xio_memory_mode=int : [rocm_xio]
+
+	Raw rocm-xio memory mode bitmap used when allocating queue and data
+	buffers.
+
+.. option:: rocm_xio_pci_mmio_bridge=bool : [rocm_xio]
+
+	Enable rocm-xio PCI MMIO bridge doorbell mode.
+
+.. option:: rocm_xio_verbose=bool : [rocm_xio]
+
+	Enable verbose rocm-xio logging.
 
 .. option:: nfs_url=str : [nfs]
 

--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,12 @@ endif
 ifdef CONFIG_LIBCUFILE
   SOURCE += engines/libcufile.c
 endif
+ifdef CONFIG_ROCM_XIO
+  rocm_xio_SRCS = engines/rocm_xio.c engines/rocm_xio_shim.cpp
+  rocm_xio_LIBS = $(ROCM_XIO_LIBS)
+  rocm_xio_CFLAGS = $(ROCM_XIO_CFLAGS)
+  ENGINES += rocm_xio
+endif
 ifdef CONFIG_LINUX_SPLICE
   SOURCE += engines/splice.c
 endif
@@ -286,10 +292,11 @@ endif
 ifdef CONFIG_DYNAMIC_ENGINES
  DYNAMIC_ENGS := $(ENGINES)
 define engine_template =
-$(1)_OBJS := $$($(1)_SRCS:.c=.o)
+$(1)_OBJS := $$(patsubst %.c,%.o,$$($(1)_SRCS))
+$(1)_OBJS := $$(patsubst %.cpp,%.o,$$($(1)_OBJS))
 $$($(1)_OBJS): CFLAGS := -fPIC $$($(1)_CFLAGS) $(CFLAGS)
 engines/fio-$(1).so: $$($(1)_OBJS)
-	$$(QUIET_LINK)$(CC) $(LDFLAGS) -shared -rdynamic -fPIC -Wl,-soname,fio-$(1).so.1 -o $$@ $$< $$($(1)_LIBS)
+	$$(QUIET_LINK)$$(if $$(filter %.cpp,$$($(1)_SRCS)),$$(CXX),$(CC)) $(LDFLAGS) -shared -rdynamic -fPIC -Wl,-soname,fio-$(1).so.1 -o $$@ $$($(1)_OBJS) $$($(1)_LIBS)
 ENGS_OBJS += engines/fio-$(1).so
 endef
 else # !CONFIG_DYNAMIC_ENGINES
@@ -309,6 +316,7 @@ override CFLAGS := -DFIO_VERSION='"$(FIO_VERSION)"' $(FIO_CFLAGS) $(CFLAGS)
 $(foreach eng,$(ENGINES),$(eval $(call engine_template,$(eng))))
 
 OBJS := $(SOURCE:.c=.o)
+OBJS := $(OBJS:.cpp=.o)
 
 FIO_OBJS = $(OBJS) fio.o
 
@@ -505,6 +513,22 @@ all: $(PROGS) $(T_TEST_PROGS) $(UT_PROGS) $(SCRIPTS) $(ENGS_OBJS) FORCE
 	@mkdir -p $(dir $@)
 	$(QUIET_CC)$(CC) -o $@ $(CFLAGS) $(CPPFLAGS) -c $<
 	@$(CC) -MM $(CFLAGS) $(CPPFLAGS) $(SRCDIR)/$*.c > $*.d
+	@mv -f $*.d $*.d.tmp
+	@sed -e 's|.*:|$*.o:|' < $*.d.tmp > $*.d
+	@if type -p fmt >/dev/null 2>&1; then				\
+		sed -e 's/.*://' -e 's/\\$$//' < $*.d.tmp | fmt -w 1 |	\
+		sed -e 's/^ *//' -e 's/$$/:/' >> $*.d;			\
+	else								\
+		sed -e 's/.*://' -e 's/\\$$//' < $*.d.tmp |		\
+		tr -cs "[:graph:]" "\n" |				\
+		sed -e 's/^ *//' -e '/^$$/ d' -e 's/$$/:/' >> $*.d;	\
+	fi
+	@rm -f $*.d.tmp
+
+%.o : %.cpp
+	@mkdir -p $(dir $@)
+	$(QUIET_CC)$(CXX) -o $@ $(CFLAGS) $(CPPFLAGS) -c $<
+	@$(CXX) -MM $(CFLAGS) $(CPPFLAGS) $(SRCDIR)/$*.cpp > $*.d
 	@mv -f $*.d $*.d.tmp
 	@sed -e 's|.*:|$*.o:|' < $*.d.tmp > $*.d
 	@if type -p fmt >/dev/null 2>&1; then				\

--- a/configure
+++ b/configure
@@ -182,6 +182,7 @@ pmem="no"
 cuda="no"
 cuda13="no"
 libcufile="no"
+rocm_xio=""
 disable_lex=""
 disable_pmem="no"
 disable_native="no"
@@ -255,6 +256,10 @@ for opt do
   ;;
   --enable-libcufile) libcufile="yes"
   ;;
+  --enable-rocm-xio) rocm_xio="yes"
+  ;;
+  --disable-rocm-xio) rocm_xio="no"
+  ;;
   --disable-native) disable_native="yes"
   ;;
   --with-ime=*) ime_path="$optarg"
@@ -326,6 +331,8 @@ if test "$show_help" = "yes" ; then
   echo "--disable-optimizations Don't enable compiler optimizations"
   echo "--enable-cuda           Enable GPUDirect RDMA support"
   echo "--enable-libcufile      Enable GPUDirect Storage cuFile support"
+  echo "--enable-rocm-xio       Enable ROCm XIO support"
+  echo "--disable-rocm-xio      Disable ROCm XIO support even if found"
   echo "--disable-native        Don't build for native host"
   echo "--with-ime=             Install path for DDN's Infinite Memory Engine"
   echo "--enable-libiscsi       Enable iscsi support"
@@ -2856,6 +2863,29 @@ fi
 print_config "libcufile" "$libcufile"
 
 ##########################################
+# Check if we have rocm-xio
+if test "$rocm_xio" != "no" ; then
+cat > $TMPC << EOF
+#include <xio.h>
+#include <nvme-ep.h>
+#include <hip/hip_runtime.h>
+int main(void)
+{
+  xio::XioEndpointConfig cfg;
+  auto ep = xio::createEndpoint("nvme-ep");
+  return ep ? 0 : 1;
+}
+EOF
+  if compile_prog "" "-lrocm-xio -lamdhip64 -lhsa-runtime64 -ldl" "rocm-xio"; then
+    rocm_xio="yes"
+    rocm_xio_libs="-lrocm-xio -lamdhip64 -lhsa-runtime64 -ldl"
+  else
+    rocm_xio="no"
+  fi
+fi
+print_config "rocm-xio engine" "$rocm_xio"
+
+##########################################
 # cuda 13 probe
 if test "$cuda" != "no" || test "$libcufile" != "no"; then
 cat > $TMPC << EOF
@@ -3441,6 +3471,10 @@ if test "$libblkio" = "yes" ; then
   output_sym "CONFIG_LIBBLKIO"
   echo "LIBBLKIO_CFLAGS=$libblkio_cflags" >> $config_host_mak
   echo "LIBBLKIO_LIBS=$libblkio_libs" >> $config_host_mak
+fi
+if test "$rocm_xio" = "yes" ; then
+  output_sym "CONFIG_ROCM_XIO"
+  echo "ROCM_XIO_LIBS=$rocm_xio_libs" >> $config_host_mak
 fi
 if test "$dynamic_engines" = "yes" ; then
   output_sym "CONFIG_DYNAMIC_ENGINES"

--- a/engines/rocm_xio.c
+++ b/engines/rocm_xio.c
@@ -1,0 +1,300 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "../fio.h"
+#include "../optgroup.h"
+#include "rocm_xio_shim.h"
+
+struct rocm_xio_options {
+	void *pad;
+	char *controller;
+	unsigned int queue_id;
+	unsigned int queue_length;
+	unsigned int nsid;
+	unsigned int lfsr_seed;
+	unsigned int batch_size;
+	unsigned int memory_mode;
+	int gpu_id;
+	int pci_mmio_bridge;
+	int verbose;
+};
+
+struct rocm_xio_data {
+	struct fio_rocm_xio_ctx *ctx;
+	unsigned int lba_size;
+};
+
+static struct fio_option options[] = {
+	{
+		.name	= "rocm_xio_controller",
+		.lname	= "ROCm XIO NVMe controller",
+		.type	= FIO_OPT_STR_STORE,
+		.off1	= offsetof(struct rocm_xio_options, controller),
+		.help	= "NVMe controller path, e.g. /dev/nvme0",
+		.category = FIO_OPT_C_ENGINE,
+		.group	= FIO_OPT_G_ROCM_XIO,
+	},
+	{
+		.name	= "rocm_xio_gpu_id",
+		.lname	= "ROCm XIO GPU ID",
+		.type	= FIO_OPT_INT,
+		.off1	= offsetof(struct rocm_xio_options, gpu_id),
+		.def	= "-1",
+		.help	= "GPU id for submitting xio kernels, -1 means current",
+		.category = FIO_OPT_C_ENGINE,
+		.group	= FIO_OPT_G_ROCM_XIO,
+	},
+	{
+		.name	= "rocm_xio_queue_id",
+		.lname	= "ROCm XIO queue id",
+		.type	= FIO_OPT_INT,
+		.off1	= offsetof(struct rocm_xio_options, queue_id),
+		.def	= "0",
+		.help	= "NVMe queue id (0 enables rocm-xio auto-detect)",
+		.category = FIO_OPT_C_ENGINE,
+		.group	= FIO_OPT_G_ROCM_XIO,
+	},
+	{
+		.name	= "rocm_xio_queue_length",
+		.lname	= "ROCm XIO queue length",
+		.type	= FIO_OPT_INT,
+		.off1	= offsetof(struct rocm_xio_options, queue_length),
+		.def	= "64",
+		.help	= "NVMe queue length in entries",
+		.category = FIO_OPT_C_ENGINE,
+		.group	= FIO_OPT_G_ROCM_XIO,
+	},
+	{
+		.name	= "rocm_xio_nsid",
+		.lname	= "ROCm XIO namespace id",
+		.type	= FIO_OPT_INT,
+		.off1	= offsetof(struct rocm_xio_options, nsid),
+		.def	= "1",
+		.help	= "NVMe namespace id",
+		.category = FIO_OPT_C_ENGINE,
+		.group	= FIO_OPT_G_ROCM_XIO,
+	},
+	{
+		.name	= "rocm_xio_lfsr_seed",
+		.lname	= "ROCm XIO LFSR seed",
+		.type	= FIO_OPT_INT,
+		.off1	= offsetof(struct rocm_xio_options, lfsr_seed),
+		.def	= "0",
+		.help	= "LFSR seed used by rocm-xio pattern generator",
+		.category = FIO_OPT_C_ENGINE,
+		.group	= FIO_OPT_G_ROCM_XIO,
+	},
+	{
+		.name	= "rocm_xio_batch_size",
+		.lname	= "ROCm XIO batch size",
+		.type	= FIO_OPT_INT,
+		.off1	= offsetof(struct rocm_xio_options, batch_size),
+		.def	= "1",
+		.help	= "SQEs per doorbell ring used by rocm-xio",
+		.category = FIO_OPT_C_ENGINE,
+		.group	= FIO_OPT_G_ROCM_XIO,
+	},
+	{
+		.name	= "rocm_xio_memory_mode",
+		.lname	= "ROCm XIO memory mode",
+		.type	= FIO_OPT_INT,
+		.off1	= offsetof(struct rocm_xio_options, memory_mode),
+		.def	= "0",
+		.help	= "rocm-xio memory_mode bitmap",
+		.category = FIO_OPT_C_ENGINE,
+		.group	= FIO_OPT_G_ROCM_XIO,
+	},
+	{
+		.name	= "rocm_xio_pci_mmio_bridge",
+		.lname	= "ROCm XIO use pci-mmio-bridge mode",
+		.type	= FIO_OPT_BOOL,
+		.off1	= offsetof(struct rocm_xio_options, pci_mmio_bridge),
+		.def	= "0",
+		.help	= "Use rocm-xio PCI MMIO bridge for doorbell writes",
+		.category = FIO_OPT_C_ENGINE,
+		.group	= FIO_OPT_G_ROCM_XIO,
+	},
+	{
+		.name	= "rocm_xio_verbose",
+		.lname	= "ROCm XIO verbose mode",
+		.type	= FIO_OPT_BOOL,
+		.off1	= offsetof(struct rocm_xio_options, verbose),
+		.def	= "0",
+		.help	= "Enable verbose rocm-xio logging",
+		.category = FIO_OPT_C_ENGINE,
+		.group	= FIO_OPT_G_ROCM_XIO,
+	},
+	{
+		.name = NULL,
+	},
+};
+
+static int fio_rocm_xio_setup(struct thread_data *td)
+{
+	struct rocm_xio_data *data;
+	struct fio_file *f;
+
+	data = calloc(1, sizeof(*data));
+	if (!data)
+		return 1;
+
+	td->io_ops_data = data;
+
+	if (!td->files_index) {
+		add_file(td, "rocm-xio", 0, 0);
+		td->o.nr_files = td->o.nr_files ? : 1;
+		td->o.open_files++;
+	}
+
+	f = td->files[0];
+	f->real_file_size = td->o.size ? td->o.size : (1ULL << 40);
+	return 0;
+}
+
+static int fio_rocm_xio_init(struct thread_data *td)
+{
+	struct rocm_xio_options *o = td->eo;
+	struct rocm_xio_data *data = td->io_ops_data;
+	struct fio_rocm_xio_options opts = { 0 };
+	struct fio_file *f;
+	int i;
+
+	if (!o->controller) {
+		log_err("rocm_xio: rocm_xio_controller must be set\n");
+		return 1;
+	}
+
+	opts.controller = o->controller;
+	opts.queue_id = o->queue_id;
+	opts.queue_length = o->queue_length;
+	opts.nsid = o->nsid;
+	opts.lfsr_seed = o->lfsr_seed;
+	opts.batch_size = o->batch_size;
+	opts.memory_mode = o->memory_mode;
+	opts.gpu_id = o->gpu_id;
+	opts.use_pci_mmio_bridge = o->pci_mmio_bridge;
+	opts.verbose = o->verbose;
+
+	if (fio_rocm_xio_init_ctx(&opts, &data->ctx) < 0 || !data->ctx) {
+		log_err("rocm_xio: failed to initialize rocm-xio context\n");
+		return 1;
+	}
+
+	if (fio_rocm_xio_get_lba_size(data->ctx, &data->lba_size) < 0) {
+		log_err("rocm_xio: failed to query lba size: %s\n",
+			fio_rocm_xio_last_error(data->ctx));
+		fio_rocm_xio_destroy_ctx(data->ctx);
+		data->ctx = NULL;
+		return 1;
+	}
+
+	for_each_file(td, f, i) {
+		if (!f->real_file_size)
+			f->real_file_size = td->o.size ? td->o.size : (1ULL << 40);
+	}
+
+	return 0;
+}
+
+static void fio_rocm_xio_cleanup(struct thread_data *td)
+{
+	struct rocm_xio_data *data = td->io_ops_data;
+
+	if (!data)
+		return;
+
+	fio_rocm_xio_destroy_ctx(data->ctx);
+	free(data);
+	td->io_ops_data = NULL;
+}
+
+static enum fio_q_status fio_rocm_xio_queue(struct thread_data *td,
+					    struct io_u *io_u)
+{
+	struct rocm_xio_data *data = td->io_ops_data;
+	int ret;
+
+	switch (io_u->ddir) {
+	case DDIR_SYNC:
+	case DDIR_DATASYNC:
+		io_u->error = 0;
+		return FIO_Q_COMPLETED;
+	case DDIR_READ:
+	case DDIR_WRITE:
+		break;
+	default:
+		io_u->error = EINVAL;
+		td_verror(td, io_u->error, "xfer");
+		return FIO_Q_COMPLETED;
+	}
+
+	if (!data || !data->ctx || !data->lba_size) {
+		io_u->error = EIO;
+		td_verror(td, io_u->error, "xfer");
+		return FIO_Q_COMPLETED;
+	}
+
+	if ((io_u->offset % data->lba_size) || (io_u->xfer_buflen % data->lba_size)) {
+		io_u->error = EINVAL;
+		td_verror(td, io_u->error, "xfer");
+		return FIO_Q_COMPLETED;
+	}
+
+	fio_ro_check(td, io_u);
+
+	ret = fio_rocm_xio_submit(data->ctx, io_u->ddir == DDIR_WRITE,
+				  io_u->offset, io_u->xfer_buflen);
+	if (ret < 0) {
+		io_u->error = EIO;
+		log_err("rocm_xio: I/O submit failed at off=%llu len=%llu: %s\n",
+			(unsigned long long) io_u->offset, io_u->xfer_buflen,
+			fio_rocm_xio_last_error(data->ctx));
+		td_verror(td, io_u->error, "xfer");
+		return FIO_Q_COMPLETED;
+	}
+
+	io_u->error = 0;
+	return FIO_Q_COMPLETED;
+}
+
+static int fio_rocm_xio_open_file(struct thread_data *td, struct fio_file *f)
+{
+	return 0;
+}
+
+static int fio_rocm_xio_invalidate(struct thread_data *td, struct fio_file *f)
+{
+	return 0;
+}
+
+FIO_STATIC struct ioengine_ops ioengine = {
+	.name			= "rocm_xio",
+	.version		= FIO_IOOPS_VERSION,
+	.flags			= FIO_SYNCIO | FIO_DISKLESSIO | FIO_NOEXTEND,
+	.setup			= fio_rocm_xio_setup,
+	.init			= fio_rocm_xio_init,
+	.cleanup		= fio_rocm_xio_cleanup,
+	.queue			= fio_rocm_xio_queue,
+	.open_file		= fio_rocm_xio_open_file,
+	.invalidate		= fio_rocm_xio_invalidate,
+	.options		= options,
+	.option_struct_size	= sizeof(struct rocm_xio_options),
+};
+
+static void fio_init fio_rocm_xio_register(void)
+{
+	register_ioengine(&ioengine);
+}
+
+static void fio_exit fio_rocm_xio_unregister(void)
+{
+	unregister_ioengine(&ioengine);
+}

--- a/engines/rocm_xio_shim.cpp
+++ b/engines/rocm_xio_shim.cpp
@@ -1,0 +1,185 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *
+ */
+
+#include "rocm_xio_shim.h"
+
+#include <cerrno>
+#include <climits>
+#include <cstring>
+#include <memory>
+#include <string>
+
+#include <hip/hip_runtime.h>
+
+#if defined(__has_include)
+#if __has_include(<rocm-xio/xio.h>)
+#include <rocm-xio/endpoints/nvme-ep/nvme-ep.h>
+#include <rocm-xio/xio.h>
+#else
+#include <nvme-ep.h>
+#include <xio.h>
+#endif
+#else
+#include <nvme-ep.h>
+#include <xio.h>
+#endif
+
+struct fio_rocm_xio_ctx {
+	struct fio_rocm_xio_options opts;
+	std::unique_ptr<xio::XioEndpoint> endpoint;
+	xio::nvme_ep::nvmeEpConfig *nvme_cfg;
+	xio::XioEndpointConfig base_cfg;
+	std::string last_error;
+	unsigned int lba_size;
+};
+
+static int set_error(struct fio_rocm_xio_ctx *ctx, const std::string &err)
+{
+	if (ctx)
+		ctx->last_error = err;
+
+	return -1;
+}
+
+int fio_rocm_xio_init_ctx(const struct fio_rocm_xio_options *opts,
+			  struct fio_rocm_xio_ctx **out_ctx)
+{
+	struct fio_rocm_xio_ctx *ctx = NULL;
+	std::string err;
+
+	if (!opts || !opts->controller || !out_ctx)
+		return -1;
+
+	ctx = new fio_rocm_xio_ctx();
+	ctx->opts = *opts;
+	ctx->nvme_cfg = NULL;
+	ctx->lba_size = 0;
+	*out_ctx = NULL;
+
+	if (ctx->opts.gpu_id >= 0) {
+		hipError_t hret = hipSetDevice(ctx->opts.gpu_id);
+
+		if (hret != hipSuccess) {
+			err = std::string("hipSetDevice failed: ") +
+			      hipGetErrorString(hret);
+			delete ctx;
+			return -1;
+		}
+	}
+
+	ctx->endpoint = xio::createEndpoint("nvme-ep");
+	if (!ctx->endpoint) {
+		delete ctx;
+		return -1;
+	}
+
+	ctx->nvme_cfg = static_cast<xio::nvme_ep::nvmeEpConfig *>(
+		ctx->endpoint->initializeEndpointConfig());
+	if (!ctx->nvme_cfg) {
+		delete ctx;
+		return -1;
+	}
+
+	ctx->nvme_cfg->controller = ctx->opts.controller;
+	ctx->nvme_cfg->queueId = ctx->opts.queue_id;
+	ctx->nvme_cfg->queueLength = ctx->opts.queue_length;
+	ctx->nvme_cfg->ioParams.nsid = ctx->opts.nsid;
+	ctx->nvme_cfg->ioParams.lfsrSeed = ctx->opts.lfsr_seed;
+	ctx->nvme_cfg->ioParams.batchSize = ctx->opts.batch_size;
+	ctx->nvme_cfg->ioParams.infiniteMode = false;
+	ctx->nvme_cfg->ioParams.accessPattern = "sequential";
+	ctx->nvme_cfg->verify = false;
+	ctx->nvme_cfg->ioParams.readIo = 1;
+	ctx->nvme_cfg->ioParams.writeIo = 0;
+	ctx->nvme_cfg->bufferParams.bufferSize = 4096;
+	ctx->nvme_cfg->doorbellParams.usePciMmioBridge =
+		ctx->opts.use_pci_mmio_bridge;
+
+	std::memset(&ctx->base_cfg, 0, sizeof(ctx->base_cfg));
+	ctx->base_cfg.numThreads = 1;
+	ctx->base_cfg.memoryMode = ctx->opts.memory_mode;
+	ctx->base_cfg.pciMmioBridge = ctx->opts.use_pci_mmio_bridge;
+	ctx->base_cfg.verbose = ctx->opts.verbose;
+	ctx->base_cfg.endpointConfig = ctx->nvme_cfg;
+
+	ctx->endpoint->applyCommonConfig(ctx->nvme_cfg, &ctx->base_cfg);
+	err = ctx->endpoint->validateConfig(ctx->nvme_cfg);
+	if (!err.empty()) {
+		set_error(ctx, err);
+		delete ctx;
+		return -1;
+	}
+
+	ctx->lba_size = ctx->nvme_cfg->ioParams.lbaSize;
+	if (!ctx->lba_size) {
+		set_error(ctx, "rocm-xio reported invalid lba size");
+		delete ctx;
+		return -1;
+	}
+
+	*out_ctx = ctx;
+	return 0;
+}
+
+void fio_rocm_xio_destroy_ctx(struct fio_rocm_xio_ctx *ctx)
+{
+	if (!ctx)
+		return;
+
+	delete ctx;
+}
+
+int fio_rocm_xio_submit(struct fio_rocm_xio_ctx *ctx, int is_write,
+			uint64_t offset, size_t len)
+{
+	hipError_t hret;
+	uint64_t lbas64;
+
+	if (!ctx || !ctx->nvme_cfg || !ctx->lba_size || !len)
+		return set_error(ctx, "invalid rocm-xio submit arguments");
+
+	if ((offset % ctx->lba_size) || (len % ctx->lba_size))
+		return set_error(ctx, "offset/length must be lba aligned");
+
+	lbas64 = len / ctx->lba_size;
+	if (!lbas64)
+		return set_error(ctx, "zero-lba transfer is not valid");
+	if (lbas64 > UINT_MAX)
+		return set_error(ctx, "transfer exceeds rocm-xio lba limits");
+	ctx->nvme_cfg->ioParams.baseLba = offset / ctx->lba_size;
+	ctx->nvme_cfg->ioParams.lbasPerIo = lbas64;
+	ctx->nvme_cfg->ioParams.readIo = is_write ? 0 : 1;
+	ctx->nvme_cfg->ioParams.writeIo = is_write ? 1 : 0;
+	ctx->nvme_cfg->bufferParams.bufferSize = len;
+	ctx->base_cfg.endpointConfig = ctx->nvme_cfg;
+
+	hret = ctx->endpoint->run(&ctx->base_cfg);
+	if (hret != hipSuccess) {
+		ctx->last_error = std::string("rocm-xio run failed: ") +
+				  hipGetErrorString(hret);
+		return -1;
+	}
+
+	return 0;
+}
+
+int fio_rocm_xio_get_lba_size(const struct fio_rocm_xio_ctx *ctx,
+			      unsigned int *lba_size)
+{
+	if (!ctx || !lba_size || !ctx->lba_size)
+		return -1;
+
+	*lba_size = ctx->lba_size;
+	return 0;
+}
+
+const char *fio_rocm_xio_last_error(const struct fio_rocm_xio_ctx *ctx)
+{
+	if (!ctx || ctx->last_error.empty())
+		return "rocm-xio unknown error";
+
+	return ctx->last_error.c_str();
+}

--- a/engines/rocm_xio_shim.h
+++ b/engines/rocm_xio_shim.h
@@ -1,0 +1,45 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *
+ */
+
+#ifndef FIO_ROCM_XIO_SHIM_H
+#define FIO_ROCM_XIO_SHIM_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct fio_rocm_xio_options {
+	const char *controller;
+	unsigned int queue_id;
+	unsigned int queue_length;
+	unsigned int nsid;
+	unsigned int lfsr_seed;
+	unsigned int batch_size;
+	unsigned int memory_mode;
+	int gpu_id;
+	int use_pci_mmio_bridge;
+	int verbose;
+};
+
+struct fio_rocm_xio_ctx;
+
+int fio_rocm_xio_init_ctx(const struct fio_rocm_xio_options *opts,
+			  struct fio_rocm_xio_ctx **out_ctx);
+void fio_rocm_xio_destroy_ctx(struct fio_rocm_xio_ctx *ctx);
+int fio_rocm_xio_submit(struct fio_rocm_xio_ctx *ctx, int is_write,
+			uint64_t offset, size_t len);
+int fio_rocm_xio_get_lba_size(const struct fio_rocm_xio_ctx *ctx,
+			      unsigned int *lba_size);
+const char *fio_rocm_xio_last_error(const struct fio_rocm_xio_ctx *ctx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/optgroup.c
+++ b/optgroup.c
@@ -178,6 +178,10 @@ static const struct opt_group fio_opt_cat_groups[] = {
 		.mask	= FIO_OPT_G_LIBCUFILE,
 	},
 	{
+		.name	= "rocm_xio I/O engine", /* rocm_xio */
+		.mask	= FIO_OPT_G_ROCM_XIO,
+	},
+	{
 		.name	= "DAOS File System (dfs) I/O engine", /* dfs */
 		.mask	= FIO_OPT_G_DFS,
 	},

--- a/optgroup.h
+++ b/optgroup.h
@@ -73,6 +73,7 @@ enum opt_category_group {
 	__FIO_OPT_G_WINDOWSAIO,
 	__FIO_OPT_G_XNVME,
 	__FIO_OPT_G_LIBBLKIO,
+	__FIO_OPT_G_ROCM_XIO,
 
 	FIO_OPT_G_RATE		= (1ULL << __FIO_OPT_G_RATE),
 	FIO_OPT_G_ZONE		= (1ULL << __FIO_OPT_G_ZONE),
@@ -120,6 +121,7 @@ enum opt_category_group {
 	FIO_OPT_G_WINDOWSAIO	= (1ULL << __FIO_OPT_G_WINDOWSAIO),
 	FIO_OPT_G_XNVME         = (1ULL << __FIO_OPT_G_XNVME),
 	FIO_OPT_G_LIBBLKIO	= (1ULL << __FIO_OPT_G_LIBBLKIO),
+	FIO_OPT_G_ROCM_XIO	= (1ULL << __FIO_OPT_G_ROCM_XIO),
 };
 
 extern const struct opt_group *opt_group_from_mask(uint64_t *mask);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Please confirm that your commit message(s) follow these guidelines:

1. First line is a commit title, a descriptive one-liner for the change
2. Empty second line
3. Commit message body that explains why the change is useful. Break lines that
   aren't something like a URL at 72-74 chars.
4. Empty line
5. Signed-off-by: Real Name <real@email.com>

Reminders:

1. If you modify struct thread_options, also make corresponding changes in
   cconv.c and bump FIO_SERVER_VER in server.h
2. If you change the ioengine interface (hooks, flags, etc), remember to bump
   FIO_IOOPS_VERSION in ioengines.h.

## Summary
- synced fork `master` with upstream `axboe/fio` (fast-forward)
- added new fio ioengine: `rocm_xio`
- added C++ shim layer (`engines/rocm_xio_shim.cpp/.h`) that bridges fio to the
  rocm-xio NVMe endpoint API (`xio::createEndpoint("nvme-ep")` and `run()`)
- wired build/config plumbing for conditional engine enablement:
  - `configure`: `--enable-rocm-xio` / `--disable-rocm-xio`, probe and output
    `CONFIG_ROCM_XIO` + `ROCM_XIO_LIBS`
  - `Makefile`: engine registration, `.cpp` object handling, and C++ link path
    support for dynamic engines
  - option grouping: `optgroup.h` and `optgroup.c`
- documented engine and options in `HOWTO.rst`

## Notes
- In this cloud environment, `rocm-xio` probe is `no` (ROCm headers/libs not
  installed), so the new engine is correctly gated out by configure.
- Full engine object build currently requires rocm-xio/ROCm dev packages
  available in the build host.

## Validation performed
- `./configure --enable-rocm-xio`
- `make clean && make -j4`
- `make engines/rocm_xio.o`
- `make engines/rocm_xio_shim.o` (fails as expected here due to missing
  `hip/hip_runtime.h`; confirms env gating behavior)

## Follow-up patch suggestions
- convert rocm_xio engine to queue reuse / async completion model for better
  iodepth scaling (current path is synchronous submit per io_u)
- add a sample `.fio` job for `rocm_xio`
- add CI job variant that enables `CONFIG_ROCM_XIO` when ROCm toolchain exists
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bac9a193-fad7-4d21-86b5-51c877172c73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bac9a193-fad7-4d21-86b5-51c877172c73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

